### PR TITLE
Trigger switch implementation with laser diode, lcd backlight settings

### DIFF
--- a/TempSensor.ino
+++ b/TempSensor.ino
@@ -224,9 +224,10 @@ MovingAverage avg_celsius;
 MovingAverage avg_fahrenheit;
 
 void loop() {
-  MovingAverage avg_celsius;
-  MovingAverage avg_fahrenheit;
-  
+  // Turn off the display:
+  lcd.noDisplay();
+  delay(refreshTempReading);
+
   // Get temperature readings
   int temp_celcius = mlx.readObjectTempC();
   int temp_fahrenheit = mlx.readObjectTempF();

--- a/TempSensor.ino
+++ b/TempSensor.ino
@@ -147,7 +147,8 @@ MLX90614 mlx = MLX90614();
 // feature flags
 const int flagMovingAverageEnable = false;
 
-const int refreshTempReading = 500;
+const int refreshTempReading = 200;
+const bool triggerState = true;
 
 // initialize the library by associating any needed LCD interface pin
 // with the arduino pin number it is connected to
@@ -224,49 +225,41 @@ MovingAverage avg_celsius;
 MovingAverage avg_fahrenheit;
 
 void loop() {
-  // Turn off the display:
-  lcd.noDisplay();
-  delay(refreshTempReading);
+  int temp_celcius;
+  int temp_fahrenheit;
 
-  // Get temperature readings
-  int temp_celcius = mlx.readObjectTempC();
-  int temp_fahrenheit = mlx.readObjectTempF();
+  switch (triggerState){
+    case true:
+      // Get temperature readings
+      temp_celcius = mlx.readObjectTempC();
+      temp_fahrenheit = mlx.readObjectTempF();
+      // Populate temperature values for moving average
+      if (flagMovingAverageEnable == true) {
+        avg_celsius.pushValue(temp_celcius);
+        avg_fahrenheit.pushValue(temp_fahrenheit);
+      }
 
-  // Populate temperature values for moving average
-  avg_celsius.pushValue(temp_celcius);
-  avg_fahrenheit.pushValue(temp_fahrenheit);
-
-  // Turn off the display:
-  lcd.noDisplay();
-  delay(refreshTempReading);
-
-  // Get temperature readings
-  int temp_celcius = mlx.readObjectTempC();
-  int temp_fahrenheit = mlx.readObjectTempF();
-
-  // Populate temperature values for moving average
-  if (flagMovingAverageEnable == true) {
-    avg_celsius.pushValue(temp_celcius);
-    avg_fahrenheit.pushValue(temp_fahrenheit);
+      lcd.setCursor(0,0);
+      if (flagMovingAverageEnable == true) {
+        lcd.print(avg_celsius.getAverage());
+      }
+      else {
+        lcd.print(temp_celcius);
+      }
+      lcd.print(" C");
+      lcd.setCursor(0,1);
+      if (flagMovingAverageEnable == true) {
+        lcd.print(avg_fahrenheit.getAverage());
+      }
+      else{
+        lcd.print(temp_fahrenheit);
+      }
+      lcd.print(" F");
+      lcd.display();
+      break;
+    case false:
+      lcd.noDisplay();
+      break;
   }
-
-  // Turn on the display:
-  lcd.setCursor(0,0);
-  if (flagMovingAverageEnable == true) {
-    lcd.print(avg_celsius.getAverage());
-  }
-  else {
-    lcd.print(temp_celcius);
-  }
-  lcd.print(" C");
-  lcd.setCursor(0,1);
-  if (flagMovingAverageEnable == true) {
-    lcd.print(avg_fahrenheit.getAverage());
-  }
-  else{
-    lcd.print(temp_fahrenheit);
-  }
-  lcd.print(" F");
-  lcd.display();
   delay(refreshTempReading);
 }

--- a/TempSensor.ino
+++ b/TempSensor.ino
@@ -224,6 +224,17 @@ MovingAverage avg_celsius;
 MovingAverage avg_fahrenheit;
 
 void loop() {
+  MovingAverage avg_celsius;
+  MovingAverage avg_fahrenheit;
+  
+  // Get temperature readings
+  int temp_celcius = mlx.readObjectTempC();
+  int temp_fahrenheit = mlx.readObjectTempF();
+
+  // Populate temperature values for moving average
+  avg_celsius.pushValue(temp_celcius);
+  avg_fahrenheit.pushValue(temp_fahrenheit);
+
   // Turn off the display:
   lcd.noDisplay();
   delay(refreshTempReading);

--- a/TempSensor.ino
+++ b/TempSensor.ino
@@ -144,16 +144,97 @@ uint16_t MLX90614::read16(uint8_t a) {
 
 MLX90614 mlx = MLX90614();
 
-// feature flags
-const int flagMovingAverageEnable = false;
+// lcd constants
+#define LCD_BRIGHTNESS_HIGH 1
+#define LCD_BRIGHTNESS_LOW 0
 
-const int refreshTempReading = 200;
-const bool triggerState = true;
+// lcd pins
+#define LCD_RS_PIN 10
+#define LCD_EN_PIN 9
+#define LCD_D4_PIN 7
+#define LCD_D5_PIN 6
+#define LCD_D6_PIN 5
+#define LCD_D7_PIN 4
+#define LCD_BL_PIN 3
+#define LCD_BR_PIN 11
+
+// trigger pins
+#define TRIGGER_PIN 2
+
+// laser pins
+#define LASER_PIN 8
+
+// operational settings
+#define REFRESH_TEMP_READING 200
+
+// feature flags
+#define FLAG_MOVING_AVG_ENABLE false
+
+class LiquidCrystalBacklight{
+  private:
+    uint8_t _backlight_pin;
+    uint8_t _brightness_pin;
+  public:
+    LiquidCrystalBacklight(uint8_t bl, uint8_t br)
+    {
+      _backlight_pin = bl;
+      _brightness_pin = br;
+    }
+
+    void display(){
+      digitalWrite(_backlight_pin, HIGH);
+      analogWrite(_brightness_pin, LCD_BRIGHTNESS_HIGH);
+    }
+    void noDisplay(){
+      digitalWrite(_backlight_pin, LOW);
+      analogWrite(_brightness_pin, LCD_BRIGHTNESS_LOW);
+    }
+};
+
+class Trigger {
+  public:
+    void begin(){
+      pinMode(TRIGGER_PIN, INPUT);
+      digitalWrite(TRIGGER_PIN, HIGH);
+    }
+    bool readTriggerStatus(){
+      return digitalRead(TRIGGER_PIN);
+    }
+};
+
+class Laser {
+  public:
+    void begin(){
+      pinMode(LASER_PIN, OUTPUT);
+    }
+    void on(){
+      digitalWrite(LASER_PIN, HIGH);
+    }
+    void off(){
+      digitalWrite(LASER_PIN, LOW);
+    }
+};
+
+// initialize trigger
+Trigger trigger;
+
+// initialize laser
+Laser laser;
 
 // initialize the library by associating any needed LCD interface pin
 // with the arduino pin number it is connected to
-const int rs = 12, en = 11, d4 = 5, d5 = 4, d6 = 3, d7 = 2;
-LiquidCrystal lcd(rs, en, d4, d5, d6, d7);
+LiquidCrystal lcd(
+  LCD_RS_PIN,
+  LCD_EN_PIN,
+  LCD_D4_PIN,
+  LCD_D5_PIN,
+  LCD_D6_PIN,
+  LCD_D7_PIN
+);
+LiquidCrystalBacklight lcd_backlight(
+  LCD_BL_PIN,
+  LCD_BR_PIN
+);
 
 class RotatingCounter {
   private:
@@ -211,13 +292,21 @@ class MovingAverage {
       m_sum = m_sum + value;
       m_rotating_counter.increment();
     }
+    void reset(){
+      m_rotating_counter.resetCounter();
+    }
 };
 
 void setup() {
+  // set up trigger button
+  trigger.begin();
+  // set up laser
+  laser.begin();
+  // set up IR sensor
   mlx.begin();
   // set up the LCD's number of columns and rows:
   lcd.begin(16, 2); 
-  lcd.home ();
+  lcd.home();
 }
 
 
@@ -228,19 +317,22 @@ void loop() {
   int temp_celcius;
   int temp_fahrenheit;
 
-  switch (triggerState){
-    case true:
+  switch (trigger.readTriggerStatus()){
+    case LOW:
+      // Start laser
+      laser.on();
+
       // Get temperature readings
       temp_celcius = mlx.readObjectTempC();
       temp_fahrenheit = mlx.readObjectTempF();
       // Populate temperature values for moving average
-      if (flagMovingAverageEnable == true) {
+      if (FLAG_MOVING_AVG_ENABLE == true) {
         avg_celsius.pushValue(temp_celcius);
         avg_fahrenheit.pushValue(temp_fahrenheit);
       }
 
       lcd.setCursor(0,0);
-      if (flagMovingAverageEnable == true) {
+      if (FLAG_MOVING_AVG_ENABLE == true) {
         lcd.print(avg_celsius.getAverage());
       }
       else {
@@ -248,18 +340,25 @@ void loop() {
       }
       lcd.print(" C");
       lcd.setCursor(0,1);
-      if (flagMovingAverageEnable == true) {
+      if (FLAG_MOVING_AVG_ENABLE == true) {
         lcd.print(avg_fahrenheit.getAverage());
       }
       else{
         lcd.print(temp_fahrenheit);
       }
       lcd.print(" F");
+      lcd_backlight.display();
       lcd.display();
       break;
-    case false:
+    case HIGH:
+      laser.off();
+      if (FLAG_MOVING_AVG_ENABLE == true) {
+        avg_celsius.reset();
+        avg_fahrenheit.reset();
+      }
+      lcd_backlight.noDisplay();
       lcd.noDisplay();
       break;
   }
-  delay(refreshTempReading);
+  delay(REFRESH_TEMP_READING);
 }

--- a/devguide.md
+++ b/devguide.md
@@ -41,8 +41,8 @@ Pin Details are as given below:
 | D3          | Backlight Control  | Backlight On               | Backlight Off               |
 | D4          | D7                 | 1                          | 0                           |
 | D5          | D6                 | 1                          | 0                           |
-| D5          | D5                 | 1                          | 0                           |
-| D6          | D4                 | 1                          | 0                           |
+| D6          | D5                 | 1                          | 0                           |
+| D7          | D4                 | 1                          | 0                           |
 | D9          | Enable             | LCD Register Access Enable | LCD Register Access Disable |
 | D10         | Register Select    | 1                          | 0                           |
 | D11         | Brightness Control | Backlight On               | Backlight Off               |


### PR DESCRIPTION
This PR implements the Trigger switch with laser diode, lcd backlight settings.

Resolves #8: Resets moving average on trigger release.

- On trigger being ON: Temperature is recorded with IR sensor. LCD and Laser Diode are enabled.
- On trigger being OFF: Temperature is recording is disabled. LCD and Laser Diode are disabled.
- Hardware pins match specifications published
- Macros are being used instead of constants for pins and code constants.